### PR TITLE
improve: mathVirtualKeyboardPolicy docs

### DIFF
--- a/mathlive/guides/virtual-keyboards/index.html
+++ b/mathlive/guides/virtual-keyboards/index.html
@@ -2288,6 +2288,11 @@ other, not both).</p>
 <td style="text-align:left"><code>&quot;manual&quot;</code></td>
 <td style="text-align:left">Do not show the virtual keyboard panel automatically. The visibility of the virtual keyboard panel can be controlled programatically with <code>mathVirtualKeyboard.show()</code> and <code>mathVirtualKeyboard.hide()</code></td>
 </tr>
+<tr>
+<td style="text-align:left"><code>&quot;sandboxed&quot;</code></td>
+<td style="text-align:left">the virtual keyboard is displayed in the current browsing context (iframe) if it has a defined container or is the
+top-level browsing context.</td>
+</tr>
 </tbody>
 </table>
 </div>


### PR DESCRIPTION
Hi! I recently got stuck when figuring out how to make keyboard work in an iframe.
Only after I found https://github.com/arnog/mathlive/issues/2067, I realized that `sandboxed` option exists.
Later I discovered it's documented in SDK Reference section but not in "Customizing the Virtual Keyboard" page which only mentions `auto` & `manual`. To avoid confusion for future users, I decided to add `sandboxed` option there too.
Thanks for a great library!